### PR TITLE
Add speed commands

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -12,4 +12,4 @@ apt-get install -qq -y --no-install-recommends \
 rm -rf /var/lib/apt/lists/*
 
 mkdir /var/discordtts
-echo '{"voice_settings":{}}' > /var/discordtts/state.json
+echo '{"voice_settings":{}, "speed_settings":{}, "speed_default_settings":{}}' > /var/discordtts/state.json

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,8 @@ pub mod join;
 pub mod leave;
 pub mod skip;
 pub mod speaker;
+pub mod setspeed;
+pub mod setdefaultspeed;
 
 async fn simple_resp_helper(
     interaction: &CommandInteraction,

--- a/src/commands/setdefaultspeed.rs
+++ b/src/commands/setdefaultspeed.rs
@@ -1,0 +1,68 @@
+use serenity::{
+    builder::{
+        CreateCommand, CreateCommandOption, CreateInteractionResponse,
+        CreateInteractionResponseMessage,
+    },
+    client::Context,
+    model::application::{CommandInteraction, CommandOptionType},
+};
+
+use crate::db::PERSISTENT_DB;
+
+pub fn register(prefix: &str) -> CreateCommand {
+    CreateCommand::new(format!("{prefix}setdefaultspeed"))
+        .description("Set the default speaking speed for your guild")
+        .dm_permission(false)
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::Number,
+                "speed",
+                "Speaking speed (1.0 to 2.0)",
+            )
+            .required(true)
+            .min_number_value(1.0)
+            .max_number_value(2.0),
+        )
+}
+
+pub async fn run(ctx: &Context, interaction: CommandInteraction) {
+    // Check if the user has the MANAGE_GUILD permission
+    if !interaction
+        .member
+        .as_ref()
+        .unwrap()
+        .permissions
+        .unwrap()
+        .manage_guild()
+    {
+        let response = CreateInteractionResponse::Message(
+            CreateInteractionResponseMessage::new()
+                .content("You need the Manage Server permission to use this command.")
+                .ephemeral(true),
+        );
+        interaction
+            .create_response(&ctx.http, response)
+            .await
+            .unwrap();
+        return;
+    }
+    let speed = interaction
+        .data
+        .options
+        .first()
+        .and_then(|opt| opt.value.as_f64())
+        .unwrap() as f32;
+
+    PERSISTENT_DB.store_speed_default(interaction.guild_id.unwrap(), speed);
+
+    let response = CreateInteractionResponse::Message(
+        CreateInteractionResponseMessage::new()
+            .content(format!("Default speaking speed set to {:.2}", speed))
+            .ephemeral(true),
+    );
+
+    interaction
+        .create_response(&ctx.http, response)
+        .await
+        .unwrap();
+}

--- a/src/commands/setspeed.rs
+++ b/src/commands/setspeed.rs
@@ -1,0 +1,48 @@
+use serenity::{
+    builder::{
+        CreateCommand, CreateCommandOption, CreateInteractionResponse,
+        CreateInteractionResponseMessage,
+    },
+    client::Context,
+    model::application::{CommandInteraction, CommandOptionType},
+};
+
+use crate::db::PERSISTENT_DB;
+
+pub fn register(prefix: &str) -> CreateCommand {
+    CreateCommand::new(format!("{prefix}setspeed"))
+        .description("Set your speaking speed")
+        .dm_permission(false)
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::Number,
+                "speed",
+                "Speaking speed (1.0 to 2.0)",
+            )
+            .required(true)
+            .min_number_value(1.0)
+            .max_number_value(2.0),
+        )
+}
+
+pub async fn run(ctx: &Context, interaction: CommandInteraction) {
+    let speed = interaction
+        .data
+        .options
+        .first()
+        .and_then(|opt| opt.value.as_f64())
+        .unwrap() as f32;
+
+    PERSISTENT_DB.store_speed(interaction.user.id, speed);
+
+    let response = CreateInteractionResponse::Message(
+        CreateInteractionResponseMessage::new()
+            .content(format!("Speaking speed set to {:.2}", speed))
+            .ephemeral(true),
+    );
+
+    interaction
+        .create_response(&ctx.http, response)
+        .await
+        .unwrap();
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,6 +17,8 @@ pub static PERSISTENT_DB: Lazy<PersistentDB> = Lazy::new(|| {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct PersistentStructure {
     voice_settings: HashMap<UserId, SpeakerId>,
+    speed_settings: HashMap<UserId, f32>,
+    speed_default_settings: HashMap<GuildId, f32>,
 }
 
 pub struct PersistentDB {
@@ -51,6 +53,48 @@ impl PersistentDB {
             .unwrap()
             .voice_settings
             .insert(user, speaker_id);
+
+        self.flush();
+    }
+
+    pub fn get_speed(&self, user: UserId, guild: GuildId) -> f32 {
+        let default_speed = self.get_speed_default(guild);
+        return self
+            .data
+            .read()
+            .unwrap()
+            .speed_settings
+            .get(&user)
+            .unwrap_or(&default_speed)
+            .to_owned();
+    }
+
+    pub fn store_speed(&self, user: UserId, speed: f32) {
+        self.data
+            .write()
+            .unwrap()
+            .speed_settings
+            .insert(user, speed);
+
+        self.flush();
+    }
+
+    pub fn get_speed_default(&self, guild: GuildId) -> f32 {
+        self.data
+            .read()
+            .unwrap()
+            .speed_default_settings
+            .get(&guild)
+            .unwrap_or(&1.0)
+            .to_owned()
+    }
+
+    pub fn store_speed_default(&self, guild: GuildId, speed: f32) {
+        self.data
+            .write()
+            .unwrap()
+            .speed_default_settings
+            .insert(guild, speed);
 
         self.flush();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ impl EventHandler for Bot {
                 commands::leave::register(&self.prefix),
                 commands::skip::register(&self.prefix),
                 commands::speaker::register(&self.prefix),
+                commands::setspeed::register(&self.prefix),
+                commands::setdefaultspeed::register(&self.prefix),
             ],
         )
         .await
@@ -56,6 +58,7 @@ impl EventHandler for Bot {
         };
 
         let speaker = PERSISTENT_DB.get_speaker_id(msg.author.id);
+        let speed = PERSISTENT_DB.get_speed(msg.author.id, msg.guild_id.unwrap());
 
         let manager = songbird::get(&ctx)
             .await
@@ -63,7 +66,7 @@ impl EventHandler for Bot {
 
         let handler = manager.get(msg.guild_id.unwrap()).unwrap();
 
-        let wav = match self.voicevox.tts(&content, speaker).await {
+        let wav = match self.voicevox.tts(&content, speaker, speed).await {
             Ok(v) => v,
             Err(_) => {
                 msg.reply(&ctx.http, "Error: Failed to synthesise a message").await.unwrap();
@@ -95,6 +98,8 @@ impl EventHandler for Bot {
                 s if s == format!("{prefix}join") => commands::join::run(&ctx, command).await,
                 s if s == format!("{prefix}leave") => commands::leave::run(&ctx, command).await,
                 s if s == format!("{prefix}skip") => commands::skip::run(&ctx, command).await,
+                s if s == format!("{prefix}setspeed") => commands::setspeed::run(&ctx, command).await,
+                s if s == format!("{prefix}setdefaultspeed") => commands::setdefaultspeed::run(&ctx, command).await,
                 _ => unreachable!("Unknown command: {}", command.data.name),
             },
             Interaction::Component(interaction) => {

--- a/src/voicevox/model.rs
+++ b/src/voicevox/model.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 pub mod api {
     use base64::{engine::general_purpose::STANDARD as base64_engine, Engine as _};
-    use serde::{de, Deserialize};
+    use serde::{de, Deserialize, Serialize};
 
     #[derive(Debug)]
     pub struct DecodedBinary {
@@ -48,6 +48,40 @@ pub mod api {
                     pub voice_samples: Vec<DecodedBinary>,
                 }
             >,
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Mora {
+        pub text: String,
+        pub consonant: Option<String>,
+        pub consonant_length: Option<f32>,
+        pub vowel: String,
+        pub vowel_length: f32,
+        pub pitch: f32,
+    }
+
+    structstruck::strike! {
+        #[strikethrough[derive(Debug, Deserialize, Serialize)]]
+        #[serde(rename_all = "camelCase")]
+        pub struct AudioQuery {
+            #[serde(rename = "accent_phrases")]
+            pub accent_phrases: Vec<pub struct {
+                #![serde(rename_all = "snake_case")]
+                pub moras: Vec<Mora>,
+                pub accent: u32,
+                pub pause_mora: Option<Mora>,
+                pub is_interrogative: bool,
+            }>,
+            pub speed_scale: f32,
+            pub pitch_scale: f32,
+            pub intonation_scale: f32,
+            pub volume_scale: f32,
+            pub pre_phoneme_length: f32,
+            pub post_phoneme_length: f32,
+            pub output_sampling_rate: u32,
+            pub output_stereo: bool,
+            pub kana: String,
         }
     }
 }


### PR DESCRIPTION
- `/setspeed`コマンドと`/setdefaultspeed`コマンドを追加
    - `/setspeed`: ユーザー単位での読み上げ速度設定
    - `/setdefaultspeed`: ギルド単位での読み上げ速度設定 (ユーザー単位での速度設定により上書き可能、MANAGE_GUILD権限を持つユーザーからのみ使用可能)
- どちらも1.0から2.0まで設定可能 (それ以上にすると聞き取り困難になったため)