### PR TITLE
fix: remove host configuration from Naver and BingSpeech

### DIFF
--- a/src/bing_speech/bing_speech_tts.rs
+++ b/src/bing_speech/bing_speech_tts.rs
@@ -40,19 +40,18 @@ fn generate_sec_ms_gec() -> String {
     hex::encode(hasher.finalize()).to_uppercase()
 }
 
-pub async fn list_voices(host: &str) -> Result<Vec<Voice>> {
+pub async fn list_voices() -> Result<Vec<Voice>> {
     use reqwest::header::{HeaderMap, HeaderValue};
 
     let url = format!(
-        "https://{}/consumer/speech/synthesize/readaloud/voices/list?trustedclienttoken={}&Sec-MS-GEC={}&Sec-MS-GEC-Version={}",
-        host,
+        "https://speech.platform.bing.com/consumer/speech/synthesize/readaloud/voices/list?trustedclienttoken={}&Sec-MS-GEC={}&Sec-MS-GEC-Version={}",
         TRUSTED_CLIENT_TOKEN,
         generate_sec_ms_gec(),
         SEC_MS_GEC_VERSION
     );
 
     let mut headers = HeaderMap::new();
-    headers.insert("Authority", HeaderValue::from_str(host)?);
+    headers.insert("Authority", HeaderValue::from_static("speech.platform.bing.com"));
     headers.insert(
         "Sec-CH-UA",
         HeaderValue::from_static(
@@ -103,7 +102,6 @@ pub async fn get_audio_bytes(
     text: &str,
     voice: &str,
     locale: &str,
-    host: &str,
     volume: f32,
 ) -> Result<Vec<u8>> {
     let parts = crate::tts::split_long_text(text, BING_SPEECH_MAX_CHARS);
@@ -115,7 +113,6 @@ pub async fn get_audio_bytes(
                 part,
                 voice.to_string(),
                 locale.to_string(),
-                host.to_string(),
             )
         })
         .collect();
@@ -140,11 +137,9 @@ async fn fetch_audio_part(
     part: String,
     voice: String,
     locale: String,
-    host: String,
 ) -> Result<Vec<u8>> {
     let url = Url::parse(&format!(
-        "wss://{}/consumer/speech/synthesize/readaloud/edge/v1?TrustedClientToken={}&Sec-MS-GEC={}&Sec-MS-GEC-Version={}",
-        host,
+        "wss://speech.platform.bing.com/consumer/speech/synthesize/readaloud/edge/v1?TrustedClientToken={}&Sec-MS-GEC={}&Sec-MS-GEC-Version={}",
         TRUSTED_CLIENT_TOKEN,
         generate_sec_ms_gec(),
         SEC_MS_GEC_VERSION

--- a/src/bing_speech/mod.rs
+++ b/src/bing_speech/mod.rs
@@ -15,7 +15,7 @@ fn default_master_volume() -> f32 {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Setting {
-    pub host: String,
+
 
     #[serde(default = "default_master_volume")]
     pub master_volume: f32,
@@ -23,7 +23,7 @@ pub struct Setting {
 
 #[derive(Debug)]
 struct BingSpeechInner {
-    host: String,
+
     master_volume: f32,
 }
 
@@ -36,7 +36,7 @@ impl BingSpeech {
     pub fn new(setting: &Setting) -> Self {
         BingSpeech {
             inner: Arc::new(BingSpeechInner {
-                host: setting.host.clone(),
+
                 master_volume: setting.master_volume,
             }),
         }
@@ -71,11 +71,11 @@ impl TtsService for BingSpeech {
         let (locale, voice) = style_id
             .split_once('/')
             .ok_or_else(|| anyhow::anyhow!("Invalid style_id format: {style_id}"))?;
-        get_audio_bytes(text, voice, locale, &self.inner.host, self.inner.master_volume).await
+        get_audio_bytes(text, voice, locale, self.inner.master_volume).await
     }
 
     async fn styles(&self) -> Result<Vec<CharacterView>> {
-        let voices = list_voices(&self.inner.host).await?;
+        let voices = list_voices().await?;
 
         let mut characters = Vec::new();
 

--- a/src/naver/mod.rs
+++ b/src/naver/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use reqwest::Url;
+
 use serde::Deserialize;
 
 use crate::tts::{CharacterView, StyleView, TtsService};
@@ -24,7 +24,7 @@ pub struct Setting {
     #[serde(default = "default_master_volume")]
     pub master_volume: f32,
 
-    pub host: Url,
+
 
     #[serde(default = "default_speed")]
     pub speed: i32,
@@ -33,7 +33,7 @@ pub struct Setting {
 #[derive(Debug)]
 struct NaverInner {
     master_volume: f32,
-    host: Url,
+
     speed: i32,
 }
 
@@ -47,7 +47,7 @@ impl Naver {
         Naver {
             inner: Arc::new(NaverInner {
                 master_volume: setting.master_volume,
-                host: setting.host.clone(),
+
                 speed: setting.speed,
             }),
         }
@@ -67,7 +67,6 @@ impl TtsService for Naver {
             voice.lang,
             voice.speaker,
             self.inner.speed,
-            &self.inner.host,
             self.inner.master_volume,
         )
         .await?;

--- a/src/naver/naver_tts.rs
+++ b/src/naver/naver_tts.rs
@@ -96,7 +96,6 @@ pub async fn get_audio_bytes(
     _lang: &str,
     speaker: &str,
     speed: i32,
-    host: &Url,
     volume: f32,
 ) -> Result<Vec<u8>> {
     use reqwest::header::{HeaderMap, HeaderValue};
@@ -105,11 +104,7 @@ pub async fn get_audio_bytes(
     let mut combined_audio = Vec::new();
 
     for part in parts {
-        let mut url = host.clone();
-        url.path_segments_mut()
-            .map_err(|()| anyhow::anyhow!("Cannot be base"))?
-            .push("api")
-            .push("nvoice");
+        let mut url = Url::parse("https://dict.naver.com/api/nvoice")?;
 
         url.query_pairs_mut()
             .append_pair("service", "dictionary")
@@ -119,7 +114,7 @@ pub async fn get_audio_bytes(
             .append_pair("speed", &speed.to_string());
 
         let mut headers = HeaderMap::new();
-        headers.insert("Referer", HeaderValue::from_str(host.as_str())?);
+        headers.insert("Referer", HeaderValue::from_static("https://dict.naver.com/"));
 
         let client = reqwest::Client::builder()
             .default_headers(headers)


### PR DESCRIPTION
- Hardcode Naver API URL to https://dict.naver.com
- Hardcode Bing Speech API URL to speech.platform.bing.com
- Remove host field from Setting structs
- Simplify configuration by eliminating unnecessary host parameter
