### PR TITLE
Add configurable languages to Google Translate backend

### DIFF
--- a/src/commands/speaker.rs
+++ b/src/commands/speaker.rs
@@ -9,7 +9,12 @@ use serenity::{
     model::application::CommandInteraction,
 };
 
-use crate::{DEFAULT_TTS_STYLE, db::PERSISTENT_DB, model::TtsStyle, tts::TtsServices};
+use crate::{
+    DEFAULT_TTS_STYLE,
+    db::PERSISTENT_DB,
+    model::TtsStyle,
+    tts::{CharacterView, TtsServices},
+};
 
 const PAGE_SIZE: usize = 25;
 
@@ -120,34 +125,39 @@ pub async fn create_modal(
 
     let mut current_character_items = vec![];
 
+    let mut current_style_items = vec![];
+
     let mut current_page_id = String::new();
 
     for (service, characters) in &styles {
-        if characters.len() <= PAGE_SIZE {
-            let first_style_id = &characters.first().unwrap().styles.first().unwrap().id;
-            let transition_target_id = format!("{service}_!DISCORDTTS!_{first_style_id}");
+        let small: Vec<&CharacterView> = characters
+            .iter()
+            .filter(|character| character.styles.len() <= PAGE_SIZE)
+            .collect();
+        let big: Vec<&CharacterView> = characters
+            .iter()
+            .filter(|character| character.styles.len() > PAGE_SIZE)
+            .collect();
 
-            pages.push((service.clone(), transition_target_id.clone()));
+        let page_count = small.len().div_ceil(PAGE_SIZE)
+            + big
+                .iter()
+                .map(|character| character.styles.len().div_ceil(PAGE_SIZE))
+                .sum::<usize>();
+        let mut page_index = 0;
 
-            if service == &voice_setting.service_id {
-                current_page_id = transition_target_id;
-                current_character_items.clone_from(characters);
-            }
-
-            continue;
-        }
-
-        let page_count = characters.len().div_ceil(PAGE_SIZE);
-        for (page_index, page_characters) in characters.chunks(PAGE_SIZE).enumerate() {
-            let page_index = page_index + 1;
-
+        for page_characters in small.chunks(PAGE_SIZE) {
+            page_index += 1;
             let first_style_id = &page_characters.first().unwrap().styles.first().unwrap().id;
             let transition_target_id = format!("{service}_!DISCORDTTS!_{first_style_id}");
 
-            pages.push((
-                format!("{service} ({page_index}/{page_count})"),
-                transition_target_id.clone(),
-            ));
+            let display = if page_count == 1 {
+                service.clone()
+            } else {
+                format!("{service} ({page_index}/{page_count})")
+            };
+
+            pages.push((display, transition_target_id.clone()));
 
             if service == &voice_setting.service_id
                 && page_characters
@@ -156,14 +166,47 @@ pub async fn create_modal(
                     .any(|style| style.id == voice_setting.style_id)
             {
                 current_page_id = transition_target_id;
-                current_character_items = page_characters.to_vec();
+                current_character_items = page_characters.iter().map(|c| (*c).clone()).collect();
+
+                current_style_items = page_characters
+                    .iter()
+                    .find(|character| {
+                        character
+                            .styles
+                            .iter()
+                            .any(|style| style.id == voice_setting.style_id)
+                    })
+                    .map(|character| character.styles.clone())
+                    .unwrap_or_default();
+            }
+        }
+
+        for character in big {
+            for style_chunk in character.styles.chunks(PAGE_SIZE) {
+                page_index += 1;
+                let first_style_id = &style_chunk.first().unwrap().id;
+                let transition_target_id = format!("{service}_!DISCORDTTS!_{first_style_id}");
+
+                pages.push((
+                    format!("{service} ({page_index}/{page_count})"),
+                    transition_target_id.clone(),
+                ));
+
+                if service == &voice_setting.service_id
+                    && style_chunk
+                        .iter()
+                        .any(|style| style.id == voice_setting.style_id)
+                {
+                    current_page_id = transition_target_id;
+                    current_character_items = vec![(*character).clone()];
+                    current_style_items = style_chunk.to_vec();
+                }
             }
         }
     }
 
     let mut characters = vec![];
 
-    let mut current_style_items = vec![];
     let mut current_character_id = String::new();
 
     for character in current_character_items {
@@ -179,7 +222,6 @@ pub async fn create_modal(
             .any(|style| style.id == voice_setting.style_id)
         {
             current_character_id = transition_target_id;
-            current_style_items = character.styles;
         }
     }
 

--- a/src/commands/speaker.rs
+++ b/src/commands/speaker.rs
@@ -9,12 +9,7 @@ use serenity::{
     model::application::CommandInteraction,
 };
 
-use crate::{
-    DEFAULT_TTS_STYLE,
-    db::PERSISTENT_DB,
-    model::TtsStyle,
-    tts::{CharacterView, TtsServices},
-};
+use crate::{DEFAULT_TTS_STYLE, db::PERSISTENT_DB, model::TtsStyle, tts::TtsServices};
 
 const PAGE_SIZE: usize = 25;
 
@@ -125,39 +120,34 @@ pub async fn create_modal(
 
     let mut current_character_items = vec![];
 
-    let mut current_style_items = vec![];
-
     let mut current_page_id = String::new();
 
     for (service, characters) in &styles {
-        let small: Vec<&CharacterView> = characters
-            .iter()
-            .filter(|character| character.styles.len() <= PAGE_SIZE)
-            .collect();
-        let big: Vec<&CharacterView> = characters
-            .iter()
-            .filter(|character| character.styles.len() > PAGE_SIZE)
-            .collect();
+        if characters.len() <= PAGE_SIZE {
+            let first_style_id = &characters.first().unwrap().styles.first().unwrap().id;
+            let transition_target_id = format!("{service}_!DISCORDTTS!_{first_style_id}");
 
-        let page_count = small.len().div_ceil(PAGE_SIZE)
-            + big
-                .iter()
-                .map(|character| character.styles.len().div_ceil(PAGE_SIZE))
-                .sum::<usize>();
-        let mut page_index = 0;
+            pages.push((service.clone(), transition_target_id.clone()));
 
-        for page_characters in small.chunks(PAGE_SIZE) {
-            page_index += 1;
+            if service == &voice_setting.service_id {
+                current_page_id = transition_target_id;
+                current_character_items.clone_from(characters);
+            }
+
+            continue;
+        }
+
+        let page_count = characters.len().div_ceil(PAGE_SIZE);
+        for (page_index, page_characters) in characters.chunks(PAGE_SIZE).enumerate() {
+            let page_index = page_index + 1;
+
             let first_style_id = &page_characters.first().unwrap().styles.first().unwrap().id;
             let transition_target_id = format!("{service}_!DISCORDTTS!_{first_style_id}");
 
-            let display = if page_count == 1 {
-                service.clone()
-            } else {
-                format!("{service} ({page_index}/{page_count})")
-            };
-
-            pages.push((display, transition_target_id.clone()));
+            pages.push((
+                format!("{service} ({page_index}/{page_count})"),
+                transition_target_id.clone(),
+            ));
 
             if service == &voice_setting.service_id
                 && page_characters
@@ -166,47 +156,14 @@ pub async fn create_modal(
                     .any(|style| style.id == voice_setting.style_id)
             {
                 current_page_id = transition_target_id;
-                current_character_items = page_characters.iter().map(|c| (*c).clone()).collect();
-
-                current_style_items = page_characters
-                    .iter()
-                    .find(|character| {
-                        character
-                            .styles
-                            .iter()
-                            .any(|style| style.id == voice_setting.style_id)
-                    })
-                    .map(|character| character.styles.clone())
-                    .unwrap_or_default();
-            }
-        }
-
-        for character in big {
-            for style_chunk in character.styles.chunks(PAGE_SIZE) {
-                page_index += 1;
-                let first_style_id = &style_chunk.first().unwrap().id;
-                let transition_target_id = format!("{service}_!DISCORDTTS!_{first_style_id}");
-
-                pages.push((
-                    format!("{service} ({page_index}/{page_count})"),
-                    transition_target_id.clone(),
-                ));
-
-                if service == &voice_setting.service_id
-                    && style_chunk
-                        .iter()
-                        .any(|style| style.id == voice_setting.style_id)
-                {
-                    current_page_id = transition_target_id;
-                    current_character_items = vec![(*character).clone()];
-                    current_style_items = style_chunk.to_vec();
-                }
+                current_character_items = page_characters.to_vec();
             }
         }
     }
 
     let mut characters = vec![];
 
+    let mut current_style_items = vec![];
     let mut current_character_id = String::new();
 
     for character in current_character_items {
@@ -222,6 +179,7 @@ pub async fn create_modal(
             .any(|style| style.id == voice_setting.style_id)
         {
             current_character_id = transition_target_id;
+            current_style_items = character.styles;
         }
     }
 

--- a/src/google_translate/mod.rs
+++ b/src/google_translate/mod.rs
@@ -14,18 +14,47 @@ fn default_master_volume() -> f32 {
     1.0
 }
 
+fn default_languages() -> Vec<Language> {
+    vec![
+        Language::new("ja", "Japanese"),
+        Language::new("ko", "Korean"),
+        Language::new("zh-CN", "Chinese (Simplified)"),
+        Language::new("zh-TW", "Chinese (Traditional)"),
+        Language::new("en", "English"),
+    ]
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct Language {
+    pub code: String,
+    pub name: String,
+}
+
+impl Language {
+    fn new(code: &str, name: &str) -> Self {
+        Language {
+            code: code.to_string(),
+            name: name.to_string(),
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct Setting {
     pub host: Url,
 
     #[serde(default = "default_master_volume")]
     pub master_volume: f32,
+
+    #[serde(default = "default_languages")]
+    pub languages: Vec<Language>,
 }
 
 #[derive(Debug)]
 struct GoogleTranslateInner {
     host: Url,
     master_volume: f32,
+    languages: Vec<Language>,
 }
 
 #[derive(Clone, Debug)]
@@ -39,6 +68,7 @@ impl GoogleTranslate {
             inner: Arc::new(GoogleTranslateInner {
                 host: setting.host.clone(),
                 master_volume: setting.master_volume,
+                languages: setting.languages.clone(),
             }),
         }
     }
@@ -60,27 +90,94 @@ impl TtsService for GoogleTranslate {
     }
 
     async fn styles(&self) -> Result<Vec<CharacterView>> {
-        let languages = vec![
-            ("ja", "Japanese"),
-            ("ko", "Korean"),
-            ("zh-CN", "Chinese (Simplified)"),
-            ("zh-TW", "Chinese (Traditional)"),
-            ("en", "English"),
-        ];
-
-        let styles = languages
-            .into_iter()
-            .map(|(id, name)| StyleView {
-                name: name.to_string(),
-                id: id.to_string(),
-                icon: vec![],
-            })
+        let languages: Vec<(String, String)> = self
+            .inner
+            .languages
+            .iter()
+            .map(|l| (l.code.clone(), l.name.clone()))
             .collect();
 
-        Ok(vec![CharacterView {
-            name: "Google Translate".to_string(),
+        Ok(chunk_characters(&languages))
+    }
+}
+
+fn chunk_characters(languages: &[(String, String)]) -> Vec<CharacterView> {
+    const CHUNK_SIZE: usize = 25;
+    let chunk_count = languages.len().div_ceil(CHUNK_SIZE);
+
+    languages
+        .chunks(CHUNK_SIZE)
+        .enumerate()
+        .map(|(i, chunk)| CharacterView {
+            name: if chunk_count == 1 {
+                "Google Translate".to_string()
+            } else {
+                format!("Google Translate ({}/{})", i + 1, chunk_count)
+            },
             policy: "Google Terms of Service".to_string(),
-            styles,
-        }])
+            styles: chunk
+                .iter()
+                .map(|(id, name)| StyleView {
+                    name: name.clone(),
+                    id: id.clone(),
+                    icon: vec![],
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_characters_fits_discord_limits() {
+        let languages: Vec<(String, String)> = (0..250)
+            .map(|i| (format!("l{i}"), format!("Lang {i}")))
+            .collect();
+
+        let characters = chunk_characters(&languages);
+
+        assert_eq!(characters.len(), 10);
+        assert!(characters.iter().all(|c| c.styles.len() <= 25));
+        assert_eq!(characters[0].name, "Google Translate (1/10)");
+        assert_eq!(characters[9].name, "Google Translate (10/10)");
+    }
+
+    #[test]
+    fn chunk_characters_stays_single_when_few() {
+        let languages = vec![("ja".to_string(), "Japanese".to_string())];
+
+        let characters = chunk_characters(&languages);
+
+        assert_eq!(characters.len(), 1);
+        assert_eq!(characters[0].name, "Google Translate");
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use crate::google_translate::{Language, Setting};
+
+    #[test]
+    fn languages_keep_config_order() {
+        let toml = r#"
+host = "https://translate.google.com"
+languages = [
+    { code = "ko", name = "Korean" },
+    { code = "ja", name = "Japanese" },
+    { code = "en", name = "English" },
+]
+"#;
+        let setting: Setting = toml::from_str(toml).unwrap();
+        assert_eq!(
+            setting.languages,
+            vec![
+                Language::new("ko", "Korean"),
+                Language::new("ja", "Japanese"),
+                Language::new("en", "English"),
+            ]
+        );
     }
 }

--- a/src/google_translate/mod.rs
+++ b/src/google_translate/mod.rs
@@ -90,69 +90,20 @@ impl TtsService for GoogleTranslate {
     }
 
     async fn styles(&self) -> Result<Vec<CharacterView>> {
-        let languages: Vec<(String, String)> = self
-            .inner
-            .languages
-            .iter()
-            .map(|l| (l.code.clone(), l.name.clone()))
-            .collect();
-
-        Ok(chunk_characters(&languages))
-    }
-}
-
-fn chunk_characters(languages: &[(String, String)]) -> Vec<CharacterView> {
-    const CHUNK_SIZE: usize = 25;
-    let chunk_count = languages.len().div_ceil(CHUNK_SIZE);
-
-    languages
-        .chunks(CHUNK_SIZE)
-        .enumerate()
-        .map(|(i, chunk)| CharacterView {
-            name: if chunk_count == 1 {
-                "Google Translate".to_string()
-            } else {
-                format!("Google Translate ({}/{})", i + 1, chunk_count)
-            },
+        Ok(vec![CharacterView {
+            name: "Google Translate".to_string(),
             policy: "Google Terms of Service".to_string(),
-            styles: chunk
+            styles: self
+                .inner
+                .languages
                 .iter()
-                .map(|(id, name)| StyleView {
-                    name: name.clone(),
-                    id: id.clone(),
+                .map(|language| StyleView {
+                    name: language.name.clone(),
+                    id: language.code.clone(),
                     icon: vec![],
                 })
                 .collect(),
-        })
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn chunk_characters_fits_discord_limits() {
-        let languages: Vec<(String, String)> = (0..250)
-            .map(|i| (format!("l{i}"), format!("Lang {i}")))
-            .collect();
-
-        let characters = chunk_characters(&languages);
-
-        assert_eq!(characters.len(), 10);
-        assert!(characters.iter().all(|c| c.styles.len() <= 25));
-        assert_eq!(characters[0].name, "Google Translate (1/10)");
-        assert_eq!(characters[9].name, "Google Translate (10/10)");
-    }
-
-    #[test]
-    fn chunk_characters_stays_single_when_few() {
-        let languages = vec![("ja".to_string(), "Japanese".to_string())];
-
-        let characters = chunk_characters(&languages);
-
-        assert_eq!(characters.len(), 1);
-        assert_eq!(characters[0].name, "Google Translate");
+        }])
     }
 }
 


### PR DESCRIPTION
Make the Google Translate speaker list configurable instead of hardcoded.

- `languages` setting: list of `{ code, name }` tables, shown in config order
- defaults to the previous 5 languages when unset
- splits into multiple characters (25 max per Discord select menu) when there are more